### PR TITLE
Github publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to Crate.io
+
+on:
+  tags:
+    - 'v-*'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: nix flake check
+
+  build:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: nix build
+
+  publish:
+    needs:
+      - test
+      - build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: nix build
+      - name: cargo publish
+        run: |- 
+          cargo publish --dry-run \
+            --all-features \
+            --target=${{ vars.PUBLISH_BUILD_TARGET }} \
+            --token=${{ secrets.CRATES_IO_API_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ categories = ["encoding"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+repository = "https://github.com/cfcosta/muhex"
 
 [dependencies]
 serde = { version = "*", optional = true }


### PR DESCRIPTION
> ⚠️ The `publish` step is set for dry-run for now.

This PR is adds a new github workflow for publishing the crate into create.io.

This workflow requires a new GH variable and a new GH secret:
- `vars.PUBLISH_BUILD_TARGET`:  One of the targets from `rustc --print target-list`;
- `secrets.CRATES_IO_API_TOKEN`: API token used to authenticate the package to create.io.