### PR TITLE
Add benchmarking for `faster-hex` encode and decode functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +262,25 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -340,6 +369,7 @@ name = "muhex"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "faster-hex",
  "hex",
  "proptest",
  "serde",
@@ -614,6 +644,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "structmeta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
+faster-hex = "0.10.0"
 hex = "0.4.3"
 proptest = "1.6.0"
 serde_json = "1.0.135"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -24,6 +24,10 @@ fn bench_compare_hex(c: &mut Criterion) {
         b.iter(|| muhex::encode(black_box(&DATA)))
     });
 
+    group.bench_function(BenchmarkId::new("encode", "faster-hex"), |b| {
+        b.iter(|| faster_hex::hex_string(black_box(DATA.as_slice())))
+    });
+
     let data = muhex::encode(DATA);
 
     group.bench_function(BenchmarkId::new("decode", "hex"), |b| {
@@ -32,6 +36,18 @@ fn bench_compare_hex(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("decode", "muhex"), |b| {
         b.iter(|| muhex::decode(black_box(&data)).unwrap())
+    });
+
+    group.bench_function(BenchmarkId::new("decode", "faster-hex"), |b| {
+        b.iter(|| {
+            let mut output = Vec::with_capacity(data.len() / 2);
+            faster_hex::hex_decode(
+                black_box(data.as_bytes()),
+                black_box(&mut output),
+            )
+            .unwrap();
+            black_box(output);
+        })
     });
 
     group.finish();


### PR DESCRIPTION
This PR adds the faster-hex crate to the benchmarks for comparison alongside the existing hex crate. The benchmark results show how muhex performs relative to both.

Benchmark highlights (from my machine):

Encode: muhex at ~7.5 GiB/s, faster-hex at ~8.5 GiB/s (both outperform hex significantly).
Decode: faster-hex leads at ~9.7 GiB/s, muhex at ~1.6 GiB/s.

