### PR TITLE
Optimize hex decoding performance with LUT-based remainder processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
-faster-hex = "0.10.0"
+faster-hex = { version = "0.10.0", features = ["serde"] }
 hex = "0.4.3"
 proptest = "1.6.0"
 serde_json = "1.0.135"
@@ -23,6 +23,7 @@ test-strategy = "0.4.0"
 [features]
 default = []
 serde = ["dep:serde", "hex/serde"]
+test-util = []
 
 [[bench]]
 name = "benchmark"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -9,56 +9,226 @@ use criterion::{
     criterion_main,
 };
 
-const DATA: &[u8; 1024 * 1024] = include_bytes!("seed.bin");
+const DATA_1MB: &[u8; 1024 * 1024] = include_bytes!("seed.bin");
 
 fn bench_compare_hex(c: &mut Criterion) {
     let mut group = c.benchmark_group("encdec");
-    group.throughput(Throughput::Bytes(DATA.len() as u64));
     group.measurement_time(Duration::from_secs(30));
 
-    group.bench_function(BenchmarkId::new("encode", "hex"), |b| {
-        b.iter(|| hex::encode(black_box(&DATA)))
-    });
+    // Test different sizes to hit different code paths
+    let test_cases = [
+        ("1MB_aligned", &DATA_1MB[..]), // 1MB - fully aligned
+        ("1KB_aligned", &DATA_1MB[..1024]), // 1KB - aligned to 32
+        ("96B_aligned", &DATA_1MB[..96]), // 96B - aligned to 32
+        ("64B_aligned", &DATA_1MB[..64]), // 64B - exactly one 64-byte chunk
+        ("63B_unaligned", &DATA_1MB[..63]), // 63B - tests 32-byte path + remainder
+        ("33B_unaligned", &DATA_1MB[..33]), // 33B - tests 32-byte + 1 byte remainder
+        ("31B_remainder", &DATA_1MB[..31]), // 31B - no 32-byte chunks, all remainder
+        ("17B_small", &DATA_1MB[..17]), // 17B - tests 16-byte SIMD remainder
+        ("15B_small", &DATA_1MB[..15]), // 15B - tests smaller SIMD remainder
+        ("7B_tiny", &DATA_1MB[..7]),    // 7B - tests LUT-only path
+        ("3B_tiny", &DATA_1MB[..3]),    // 3B - minimal LUT path
+        ("1B_minimal", &DATA_1MB[..1]), // 1B - edge case
+    ];
 
-    group.bench_function(BenchmarkId::new("encode", "muhex"), |b| {
-        b.iter(|| muhex::encode(black_box(&DATA)))
-    });
+    for (name, data) in test_cases.iter() {
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
-    group.bench_function(BenchmarkId::new("encode", "faster-hex"), |b| {
-        b.iter(|| faster_hex::hex_string(black_box(DATA.as_slice())))
-    });
+        // Encode benchmarks
+        group.bench_function(BenchmarkId::new("encode/hex", name), |b| {
+            b.iter(|| hex::encode(black_box(data)))
+        });
 
-    let data = muhex::encode(DATA);
+        group.bench_function(BenchmarkId::new("encode/muhex", name), |b| {
+            b.iter(|| muhex::encode(black_box(data)))
+        });
 
-    group.bench_function(BenchmarkId::new("decode", "hex"), |b| {
-        b.iter(|| hex::decode(black_box(&data)).unwrap())
-    });
+        group
+            .bench_function(BenchmarkId::new("encode/faster-hex", name), |b| {
+                b.iter(|| faster_hex::hex_string(black_box(*data)))
+            });
 
-    group.bench_function(BenchmarkId::new("decode", "muhex"), |b| {
-        b.iter(|| muhex::decode(black_box(&data)).unwrap())
-    });
+        // Decode benchmarks
+        let encoded = muhex::encode(data);
+        group.bench_function(BenchmarkId::new("decode/hex", name), |b| {
+            let mut output = vec![0; encoded.len() / 2];
+            b.iter(|| {
+                hex::decode_to_slice(
+                    black_box(&encoded),
+                    black_box(output.as_mut_slice()),
+                )
+                .unwrap()
+            });
+            black_box(output.as_slice());
+        });
+        group.bench_function(BenchmarkId::new("decode/muhex", name), |b| {
+            let mut output = vec![0; encoded.len() / 2];
+            b.iter(|| {
+                muhex::decode_to_buf(
+                    black_box(&encoded),
+                    black_box(output.as_mut_slice()),
+                )
+                .unwrap();
+                black_box(output.as_slice());
+            })
+        });
+        group.bench_function(
+            BenchmarkId::new("decode/faster-hex", name),
+            |b| {
+                let mut output = vec![0; encoded.len() / 2];
+                b.iter(|| {
+                    faster_hex::hex_decode(
+                        black_box(encoded.as_bytes()),
+                        black_box(&mut output),
+                    )
+                    .unwrap();
+                    black_box(output.as_slice());
+                })
+            },
+        );
+    }
 
-    group.bench_function(BenchmarkId::new("decode", "faster-hex"), |b| {
-        b.iter(|| {
-            let mut output = Vec::with_capacity(data.len() / 2);
-            faster_hex::hex_decode(
-                black_box(data.as_bytes()),
-                black_box(&mut output),
-            )
-            .unwrap();
-            black_box(output);
-        })
-    });
+    group.finish();
+}
+
+// Benchmark to compare LUT vs SIMD remainder strategies directly
+#[cfg(feature = "test-util")]
+fn bench_remainder_strategies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("remainder_strategy");
+    group.measurement_time(Duration::from_secs(20));
+
+    // Test pure remainder processing (no main loop)
+    let pure_remainder_sizes = [
+        ("2B_1pair", 2),
+        ("4B_2pairs", 4),
+        ("6B_3pairs", 6),
+        ("8B_4pairs", 8),
+        ("12B_6pairs", 12),
+        ("16B_8pairs", 16),
+        ("20B_10pairs", 20),
+        ("24B_12pairs", 24),
+        ("30B_15pairs", 30),
+    ];
+
+    for (name, hex_len) in pure_remainder_sizes {
+        let data = &DATA_1MB[..hex_len / 2];
+        let encoded = muhex::encode(data);
+        let input_bytes = encoded.as_bytes();
+
+        group.throughput(Throughput::Bytes(data.len() as u64));
+
+        // Benchmark SIMD remainder directly
+        group.bench_function(BenchmarkId::new("simd", name), |b| {
+            let mut output = vec![std::mem::MaybeUninit::uninit(); data.len()];
+            b.iter(|| {
+                muhex::decode_remainder_simd_bench(
+                    black_box(input_bytes),
+                    black_box(&mut output),
+                    0,
+                    0,
+                    input_bytes.len(),
+                )
+                .unwrap();
+                black_box(output.as_slice());
+            })
+        });
+
+        // Benchmark LUT remainder directly
+        group.bench_function(BenchmarkId::new("lut", name), |b| {
+            let mut output = vec![std::mem::MaybeUninit::uninit(); data.len()];
+            b.iter(|| {
+                muhex::decode_remainder_lut_bench(
+                    black_box(input_bytes),
+                    black_box(&mut output),
+                    0,
+                    0,
+                    input_bytes.len(),
+                )
+                .unwrap();
+                black_box(output.as_slice());
+            })
+        });
+    }
+
+    group.finish();
+}
+
+// More detailed remainder comparison with warmup
+#[cfg(feature = "test-util")]
+fn bench_remainder_detailed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("remainder_detailed");
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(5));
+
+    // Pre-allocate output buffers to avoid allocation overhead
+    let sizes = [
+        ("1_pair", 1),
+        ("2_pairs", 2),
+        ("3_pairs", 3),
+        ("4_pairs", 4),
+        ("5_pairs", 5),
+        ("6_pairs", 6),
+        ("7_pairs", 7),
+        ("8_pairs", 8),
+        ("9_pairs", 9),
+        ("10_pairs", 10),
+        ("11_pairs", 11),
+        ("12_pairs", 12),
+        ("13_pairs", 13),
+        ("14_pairs", 14),
+        ("15_pairs", 15),
+    ];
+
+    for (name, pairs) in sizes {
+        let byte_len = pairs;
+        let data = &DATA_1MB[..byte_len];
+        let encoded = muhex::encode(data);
+        let input_bytes = encoded.as_bytes();
+
+        group.throughput(Throughput::Bytes(byte_len as u64));
+
+        // SIMD with pre-allocated buffer
+        group.bench_function(BenchmarkId::new("simd", name), |b| {
+            let mut output = vec![std::mem::MaybeUninit::uninit(); byte_len];
+            b.iter(|| {
+                muhex::decode_remainder_simd_bench(
+                    black_box(input_bytes),
+                    black_box(&mut output),
+                    0,
+                    0,
+                    input_bytes.len(),
+                )
+                .unwrap();
+                black_box(output.as_slice());
+            })
+        });
+
+        // LUT with pre-allocated buffer
+        group.bench_function(BenchmarkId::new("lut", name), |b| {
+            let mut output = vec![std::mem::MaybeUninit::uninit(); byte_len];
+            b.iter(|| {
+                muhex::decode_remainder_lut_bench(
+                    black_box(input_bytes),
+                    black_box(&mut output),
+                    0,
+                    0,
+                    input_bytes.len(),
+                )
+                .unwrap();
+                black_box(output.as_slice());
+            })
+        });
+    }
 
     group.finish();
 }
 
 #[cfg(feature = "serde")]
 fn bench_serde(c: &mut Criterion) {
-    let test_data = DATA.to_vec();
+    let test_data = DATA_1MB.to_vec();
 
     let mut group = c.benchmark_group("serde");
-    group.throughput(Throughput::Bytes(DATA.len() as u64));
+    group.throughput(Throughput::Bytes(DATA_1MB.len() as u64));
     group.measurement_time(Duration::from_secs(30));
 
     group.bench_function(BenchmarkId::new("serialize", "hex"), |b| {
@@ -82,7 +252,8 @@ fn bench_serde(c: &mut Criterion) {
     });
 
     let serialized =
-        muhex::serialize(&test_data, serde_json::value::Serializer).unwrap();
+        muhex::serde::serialize(&test_data, serde_json::value::Serializer)
+            .unwrap();
 
     group.bench_function(BenchmarkId::new("deserialize", "hex"), |b| {
         b.iter(|| {
@@ -104,5 +275,17 @@ fn bench_serde(c: &mut Criterion) {
 #[cfg(not(feature = "serde"))]
 fn bench_serde(_c: &mut Criterion) {}
 
-criterion_group!(benches, bench_compare_hex, bench_serde);
+#[cfg(not(feature = "test-util"))]
+fn bench_remainder_strategies(_c: &mut Criterion) {}
+
+#[cfg(not(feature = "test-util"))]
+fn bench_remainder_detailed(_c: &mut Criterion) {}
+
+criterion_group!(
+    benches,
+    bench_compare_hex,
+    bench_serde,
+    bench_remainder_strategies,
+    bench_remainder_detailed,
+);
 criterion_main!(benches);


### PR DESCRIPTION
# Optimize hex decoding performance with LUT-based remainder processing

## Overview
This PR significantly improves hex decoding performance by replacing SIMD-based remainder processing with a lookup table (LUT) approach and optimizing the validation path in the main SIMD loops. The optimizations reduce code complexity and improve instruction cache utilization
## Key Changes

### 1. Extracted `decode_into` as separate function
- **Before**: All decoding logic inlined into wrapper, creating massive 2000+ line function
- **After**: Core logic in `decode_into`, wrapper handles allocation only
- Results in cleaner assembly with better register allocation
- Enables compiler to optimize the hot path independently

**Assembly comparison:**
```asm
// Before: Inline everything (~2000 lines)
decode_mu_hex:
    push rbp / r15 / r14 / r13 / r12 / rbx
    and rsp, -32        # 32-byte alignment
    sub rsp, 224        # Huge stack frame
    [... 2000+ lines of inlined SIMD code ...]

// After: Clean separation (~100 lines)  
decode_mu_hex:
    push r15 / r14 / r13 / r12 / rbx
    sub rsp, 16         # Minimal stack (16 bytes vs 224)
    call muhex::decode_into@GOTPCREL  # Separate optimized function
    ret
```

### 2. LUT-Based Remainder Processing
- **Problem**: SIMD remainder generated 16 unrolled `vpextrb` instructions with bounds checks (~500+ lines assembly)
- **Solution**: Simple lookup table for remainders (< 32 bytes)
- **Benefits**:
    - No SIMD register setup overhead
    - No data shuffling or byte extraction
    - Predictable branches (better speculation)
    - Minimal stack usage
    - Smaller code footprint (better i-cache)
```rust
// Compile-time lookup table
const HEX_DECODE_LUT: [u8; 256] = { /* precomputed */ };

// Tight loop for remainder
while pos < end {
    let hi = HEX_DECODE_LUT[input[pos] as usize];
    let lo = HEX_DECODE_LUT[input[pos + 1] as usize];
    if (hi | lo) == 255 { return Err(...); }  // Single branch
    output[out_pos].write((hi << 4) | lo);
    pos += 2;
}
```

### 3. Optimized Stack Usage
- **Before**: 224 bytes stack + 32-byte alignment
- **After**: 16 bytes stack + natural alignment
- Reduced function prologue/epilogue overhead
- Better register pressure management

## Assembly Impact Analysis

**Before**: ~2000 lines with all SIMD code inlined  
**After**: ~100 lines calling separated function
```asm
# Stack allocation
Before: sub rsp, 224
After:  sub rsp, 16         # 14x smaller

# Function size  
Before: 2000+ lines (includes all SIMD processing inline)
After:  ~100 lines (clean wrapper + call)
```

### Core Loop (decode_into)
Now in separate compilation unit with better optimization:
- Tighter SIMD loops (no validation overhead)
- Better register allocation
- Improved instruction scheduling
- More aggressive inlining of helpers

### Remainder Processing
**Before** (SIMD with vpextrb):
```asm
vpextrb byte ptr [r14 + r12], xmm0, 0
cmp rcx, 2
je .skip1
vpextrb byte ptr [r14 + rax], xmm0, 1
cmp rcx, 3
je .skip2
# ... 14 more unrolled iterations
# Total: ~500 lines with bounds checks
```

**After** (LUT):
```asm
movzx eax, byte ptr [rsi]       # Load high nibble
movzx ecx, byte ptr [rsi + 1]   # Load low nibble  
mov al, byte ptr [rax + LUT]    # Lookup high
or al, byte ptr [rcx + LUT]     # Lookup low & combine
cmp al, 255                      # Check validity (1 branch)
je .error
mov byte ptr [rdi], result      # Store
add rsi, 2
inc rdi
cmp rsi, end
jb .loop
# Total: ~15 lines tight loop
```

## Benchmark Suite Enhancements

Added comprehensive benchmarking infrastructure:

### 1. Multi-Size Testing
Tests 12 different input sizes from 1B to 1MB:
- Aligned sizes (64B, 96B, 1KB, 1MB)
- Unaligned sizes (63B, 33B, 31B, 17B, 15B, 7B, 3B, 1B)
- Validates performance across all code paths

### 2. Strategy Comparison Benchmarks
New `test-util` feature enables direct comparison:
```rust
#[cfg(feature = "test-util")]
pub fn decode_remainder_simd_bench(...) { }  // Old SIMD path
pub fn decode_remainder_lut_bench(...) { }   // New LUT path
```

### 3. Detailed Profiling
- `bench_remainder_strategies`: Tests pure remainder (2B-30B)
- `bench_remainder_detailed`: Per-pair granularity (1-15 pairs)
