### PR TITLE
seal Buf trait and make dst() method unsafe for soundness and safety

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,17 +1,43 @@
 use std::mem::MaybeUninit;
 
-pub trait Buf {
-    fn dst(&mut self) -> &mut [MaybeUninit<u8>];
+/// Private sealing trait - prevents external implementations
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for [std::mem::MaybeUninit<u8>] {}
+    impl Sealed for [u8] {}
+}
+
+/// Public trait for types that can be used as hex encoding/decoding buffers.
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+/// It is implemented for `[MaybeUninit<u8>]` and `[u8]`.
+pub trait Buf: private::Sealed {
+    /// Returns a mutable reference to the buffer as `MaybeUninit<u8>` slices.
+    ///
+    /// # Safety
+    ///
+    /// The caller MUST only write fully initialized bytes through the returned
+    /// reference. Writing uninitialized bytes when the underlying buffer is
+    /// `&mut [u8]` is undefined behavior.
+    ///
+    /// This method is not directly callable by external code.
+    #[doc(hidden)]
+    unsafe fn dst(&mut self) -> &mut [MaybeUninit<u8>];
 }
 
 impl Buf for [MaybeUninit<u8>] {
-    fn dst(&mut self) -> &mut [MaybeUninit<u8>] {
+    unsafe fn dst(&mut self) -> &mut [MaybeUninit<u8>] {
         self
     }
 }
 
 impl Buf for [u8] {
-    fn dst(&mut self) -> &mut [MaybeUninit<u8>] {
+    unsafe fn dst(&mut self) -> &mut [MaybeUninit<u8>] {
+        // SAFETY: This is sound because:
+        // 1. T and MaybeUninit<T> are ABI-compatible
+        // 2. The lifetime of the reference is tied to &mut self, preventing aliasing
+        // 3. The caller is responsible for only writing initialized bytes (per trait contract)
         unsafe {
             std::slice::from_raw_parts_mut(self.as_mut_ptr().cast(), self.len())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,8 @@ where
 {
     let data = v.as_ref();
     let expected_len = data.len() * 2;
-    let dst = dst.dst();
+    // SAFETY: We only write fully initialized bytes through encode_simd_* and encode_scalar
+    let dst = unsafe { dst.dst() };
     if dst.len() != expected_len {
         return Err(Error::new(
             ErrorKind::InvalidInput,
@@ -179,7 +180,8 @@ where
 {
     let input = input.as_bytes();
     let expected_len = required_output_len(input.len())?;
-    let output = output.dst();
+    // SAFETY: We only write fully initialized bytes through decode_into
+    let output = unsafe { output.dst() };
     if output.len() != expected_len {
         return Err(Error::new(
             ErrorKind::InvalidInput,


### PR DESCRIPTION
## Problem

The `Buf` trait was unsound. It allowed transmuting `&mut [u8]` to `&mut [MaybeUninit<u8>]` through a safe interface, which could be exploited to cause undefined behavior.

## Solution

This PR makes the trait sound using the sealed trait pattern:

1. **`private::Sealed`** - Empty trait in private module, implemented only for `[u8]` and `[MaybeUninit<u8>]`
2. **`Buf: private::Sealed`** - Public trait requires the sealed trait, preventing external implementations
3. **`unsafe fn dst()`** - Method marked unsafe with documented safety requirement: callers must only write initialized bytes
4. **Safety comments** - Added at all call sites documenting why the invariant is upheld

## Safety Guarantee

The library maintains the invariant that only fully initialized bytes are written through `dst()`:
- `encode_to_buf` writes through `encode_simd_*` and `encode_scalar`, all of which write initialized bytes
- `decode_to_buf` writes through `decode_into`, which writes initialized bytes